### PR TITLE
Move pygoject dep from framework dep to examples dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,9 @@ Flask==1.1.1
 jsonpickle>=1.3
 requests>=2.23.0
 psutil>=5.7.0
-pygobject~=3.36.1
 
 ### examples
-
+pygobject~=3.36.1
 # Needed only for stress tests and batchkit_examples/speech_sdk:
 # NOTE: Speech SDK v1.11.0 has a bug during broken session reconnection with SRFrontEnd; blacklisted
 azure-cognitiveservices-speech==1.10.0

--- a/setup_batchkit.py
+++ b/setup_batchkit.py
@@ -31,7 +31,7 @@ for line in required:
 # Package specification for batchkit library.
 setup(
     name='batchkit',
-    version='0.9.2-dev1',
+    version='0.9.2-dev2',
     author='Microsoft Azure',
     author_email='andwald@microsoft.com',
     description="Generic batch processing framework for managing the orchestration, dispatch, fault tolerance, and "

--- a/setup_examples.py
+++ b/setup_examples.py
@@ -17,7 +17,7 @@ deps = [line for line in required if len(line) > 0 and line[0] != "#"]
 # Package specification that includes every example.
 setup(
     name='batchkit_examples_speechsdk',
-    version='0.9.2-dev1',
+    version='0.9.2-dev2',
     author='Microsoft Azure',
     author_email='andwald@microsoft.com',
     url='https://github.com/microsoft/batch-processing-kit',


### PR DESCRIPTION
Move pygoject dep from framework dep to examples dep since not needed in the framework. Smaller foolprint and fast pip install of base framework.