### PR TITLE
 Listen on all interfaces inside the container

### DIFF
--- a/batchkit/apiserver.py
+++ b/batchkit/apiserver.py
@@ -95,7 +95,7 @@ class ApiServer(object):
             Thread(
                 target=self.flask_app.run,
                 kwargs={
-                    "host": "localhost", "port": port,
+                    "host": "0.0.0.0", "port": port,
                     "debug": True, "use_reloader": False},
                 name="MainProc_FlaskAppParentThread",
                 daemon=True


### PR DESCRIPTION
This solves Connection Refused when trying to reach endpoint from outside the container. Could not port forward to the container.

Link explaining the issue: https://pythonspeed.com/articles/docker-connection-refused/