### PR TITLE
Lazy init EndpointManager's multiproc worker pool

### DIFF
--- a/batchkit/utils.py
+++ b/batchkit/utils.py
@@ -210,7 +210,10 @@ class NonDaemonicPool(pool.Pool):
             self._repopulate_pool()
 
     def set_min_num_procs(self, num_procs):
+        # We only grow the pool size.
         if num_procs > self._processes:
+            # Set the intention to grow asynchronously, but don't modify data struct directly.
+            # The pool manager's synchronous path will invoke _maintain_pool() to take it up.
             self.target_num_procs = num_procs
 
 

--- a/setup_batchkit.py
+++ b/setup_batchkit.py
@@ -31,7 +31,7 @@ for line in required:
 # Package specification for batchkit library.
 setup(
     name='batchkit',
-    version='0.9.7',
+    version='0.9.8.dev0',
     author='Microsoft Azure',
     author_email='andwald@microsoft.com',
     description="Generic batch processing framework for managing the orchestration, dispatch, fault tolerance, and "

--- a/setup_examples.py
+++ b/setup_examples.py
@@ -17,7 +17,7 @@ deps = [line for line in required if len(line) > 0 and line[0] != "#"]
 # Package specification that includes every example.
 setup(
     name='batchkit_examples_speechsdk',
-    version='0.9.2-dev2',
+    version='0.9.8.dev0',
     author='Microsoft Azure',
     author_email='andwald@microsoft.com',
     url='https://github.com/microsoft/batch-processing-kit',


### PR DESCRIPTION
Lazy init EndpointManager's multiproc worker pool for higher efficiency when dealing with many endpoints that will be ill-suited to the type (e.g. locale) of batch being done. In multi-language case, would create far fewer processes.

Also ix a bug that endpoint hotswapping (also done at start of each batch) need to recreate terminally stopped endpoints but weren't.
