### PR TITLE
Daemon mode support cifs/smb/nfs; ensure work item discovery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ batchkit/__pycache__/
 batchkit_examples/__pycache__/
 batchkit_examples/speech_sdk/__pycache__/
 tests/__pycache__/
+venv/
 
 # PyCharm associated
 .idea/

--- a/batchkit_examples/speech_sdk/parser.py
+++ b/batchkit_examples/speech_sdk/parser.py
@@ -4,6 +4,7 @@
 import argparse
 from argparse import Namespace
 import os
+import tempfile
 
 
 def check_positive(value):
@@ -79,7 +80,7 @@ def create_parser():
         required=False,
         help="[Optional] Scratch folder will be created if it doesn't"
              "exist and is cleaned on exit. If unspecified, a temporary"
-             "directory is used under --output-folder."
+             "directory is used under /tmp"
     )
     parser.add_argument(
         '-diarization', '--diarization-mode',
@@ -128,6 +129,6 @@ def parse_cmdline(args=None) -> Namespace:
         parser.error("argument -input_list/--input-list: not allowed if the run mode is not ONESHOT")
 
     if args.scratch_folder is None:
-        args.scratch_folder = os.path.join(args.output_folder, ".scratch")
+        args.scratch_folder = tempfile.mkdtemp()
 
     return args


### PR DESCRIPTION
Add polling via find and touch for the input directory file changes when in daemon mode to cover the case of network filesystem drivers not being compatible with posix inotify. In this case batchkit will still get the file added notifications and add them to work queue but there may be higher latency since no longer truly event driven (but much better than never seeing those new files). Default scratch to a temp dir made under /tmp in container filesystem instead of being under output dir since sometimes this causes deadlocks when using smb/cifs as the output dir.