### PR TITLE
DAEMON mode filesystem polling for new input files as posix watch alternative.

### DIFF
--- a/batchkit/orchestrator.py
+++ b/batchkit/orchestrator.py
@@ -497,7 +497,8 @@ class Orchestrator:
             self._in_progress = work_in_progress
             self._in_progress_owner = work_in_progress_owner
 
-            # We've potentially repopulated the file_queue.
+            # We've potentially repopulated the file_queue, and old endpoint managers who were blocked waiting
+            # for work should now be woken up to be told of their termination.
             self._file_queue_cond.notify_all()
 
             # Start the new EndpointManagers.

--- a/batchkit_examples/speech_sdk/parser.py
+++ b/batchkit_examples/speech_sdk/parser.py
@@ -113,6 +113,13 @@ def create_parser():
         '-port', '--apiserver_port', default=5000, type=check_positive,
         help="Port for listening when using APISERVER mode"
     )
+    parser.add_argument(
+        '-poll', '--poll', default=False, action='store_true',
+        help="In DAEMON mode, toggle to periodically poll the input directory for new files instead of relying "
+             "only on the Posix Watches facility. This is needed to make DAEMON mode work with filesystems that "
+             "do not support Posix Watches, for example CIFS mount. Polling is an increased burden on the filesystem. "
+             "Applies to --run-mode DAEMON only."
+    )
     return parser
 
 

--- a/tests/test_e2e_stress_mock_speechsdk.py
+++ b/tests/test_e2e_stress_mock_speechsdk.py
@@ -308,6 +308,7 @@ class UnstableSDKTestCase(object):
                             '-m', 'DAEMON' if daemon_mode else 'ONESHOT',
                             '-profanity', 'Raw',
                             '--store-combined-json',
+                            '--poll'  # watcher also applied; tests works with both at same time.
                         ]
 
                         if daemon_mode:


### PR DESCRIPTION
Add support for polling the filesystem for new files in DAEMON mode instead of having to only rely on posix watcher facility. Needed for some filesystems like CIFS where watches not supported (event dont trigger)