### PR TITLE
(1) Framework-level global work item lock as optional feature (2) Improve Debuggability.

### DIFF
--- a/batchkit/apiserver.py
+++ b/batchkit/apiserver.py
@@ -5,7 +5,6 @@ import multiprocessing
 from http import HTTPStatus
 from threading import Thread
 from typing import Tuple, Optional, List, Callable
-import logging
 
 from flask import Flask, Response, Blueprint, request
 

--- a/batchkit/client.py
+++ b/batchkit/client.py
@@ -33,6 +33,7 @@ Settings = namedtuple("Settings",
                       "input_folder input_list output_folder "           # ONESHOT or DAEMON modes only.
                       "poll_input "                                      # DAEMON mode only.
                       "apiserver_port "                                  # APISERVER mode only.
+                      "debug_loop_interval "
                       "scratch_folder log_folder store_combined_json "
                       "config_file strict_configuration_validation ")
 
@@ -97,6 +98,7 @@ def run(cmd_args: Namespace, batch_type: type):
         apiserver_port=cmd_args.apiserver_port,
 
         # Following args are relevant in all modes.
+        debug_loop_interval=cmd_args.debug_loop_interval,
         scratch_folder=cmd_args.scratch_folder,
         log_folder=cmd_args.log_folder,
         config_file=cmd_args.configuration_file,
@@ -200,6 +202,9 @@ class Client(ABC):
             # LogEventQueue is a more direct path for logging in concurrent
             # multi-process scenarios.
             log_queue,
+
+            # How often to do tracing of orchestration state.
+            self.settings.debug_loop_interval,
 
             # Client type will determine whether run summary is singleton
             # in nature or reported per-batch.

--- a/batchkit/constants.py
+++ b/batchkit/constants.py
@@ -3,7 +3,6 @@
 
 ORCHESTRATOR_SCOPE_MAX_RETRIES = 9    # Includes all retries. How # before orchestrator won't reschedule.
 RUN_SUMMARY_LOOP_INTERVAL = 30        # How often the run summary is recomputed and written.
-DEBUG_LOOP_INTERVAL = 30              # Applies only when debug thread enabled.
 
 # The number of times we will retry a SpeechSDKWorkItem as
 # long as its previous reasons for failure appear to be transient issues

--- a/batchkit/endpoint_status.py
+++ b/batchkit/endpoint_status.py
@@ -2,12 +2,8 @@
 # Licensed under the MIT License.
 
 from abc import ABC, abstractmethod
-import logging
 
 from .logger import LogEventQueue
-
-
-logger = logging.getLogger("batch")
 
 
 class EndpointStatusChecker(ABC):

--- a/batchkit_examples/speech_sdk/parser.py
+++ b/batchkit_examples/speech_sdk/parser.py
@@ -120,6 +120,12 @@ def create_parser():
              "do not support Posix Watches, for example CIFS mount. Polling is an increased burden on the filesystem. "
              "Applies to --run-mode DAEMON only."
     )
+    parser.add_argument(
+        '-debug_loop_interval', '--debug-loop-interval',
+        default=0, type=check_positive,
+        help="Interval in seconds to re-log debug information about the batchkit's orchestration components. "
+             "Useful for debugging. The default value of 0 means this information is not logged. "
+    )
     return parser
 
 

--- a/batchkit_examples/speech_sdk/run-batch-client
+++ b/batchkit_examples/speech_sdk/run-batch-client
@@ -5,6 +5,9 @@
 
 import sys
 import os
+import glob
+from argparse import Namespace
+from typing import List
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 
@@ -15,6 +18,6 @@ from batchkit_examples.speech_sdk.batch_config import SpeechSDKBatchConfig
 
 # Main entry point
 if __name__ == '__main__':
-    args = parse_cmdline()
+    args: Namespace = parse_cmdline()
     client.run(args, SpeechSDKBatchConfig)
     exit(0)

--- a/batchkit_examples/speech_sdk/work_item.py
+++ b/batchkit_examples/speech_sdk/work_item.py
@@ -39,7 +39,8 @@ class SpeechSDKWorkItemRequest(WorkItemRequest):
         self._cached_duration = None
 
     def process_impl(self, endpoint_config: dict, rtf: float,
-                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event):
+                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
+                     global_workitem_lock: multiprocessing.RLock):
         from .recognize import run_recognizer
         return run_recognizer(
             self,

--- a/tests/test_batch_request_dependency_injection.py
+++ b/tests/test_batch_request_dependency_injection.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import multiprocessing
+from multiprocessing import RLock
 from argparse import Namespace
 from typing import List, Dict
 from unittest import TestCase
@@ -37,8 +38,9 @@ class TWorkItemRequest(WorkItemRequest):
         self.output_dir = output_dir
         self.some_int = some_int
 
-    def process_impl(self, endpoint_config: dict, rtf: float, log_event_queue: LogEventQueue,
-                     cancellation_token: multiprocessing.Event):
+    def process_impl(self, endpoint_config: dict, rtf: float,
+                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
+                     global_workitem_lock: RLock):
         log_event_queue.info("Did the work")
 
 


### PR DESCRIPTION
(1) Add framework feature of providing work items with an RLock for critical section in case needed in any application. Usage is optional.

(2) Add debuggability into the framework. More trace logging (debug level), and add the '--debug-loop-interval' option which enables the debug loop in Orchestrator at user's choice instead of requiring code toggle.
