### PR TITLE
Add WorkItemProcessor abstraction into the framework

### DIFF
--- a/batchkit/batch_request.py
+++ b/batchkit/batch_request.py
@@ -18,6 +18,8 @@ from .logger import LogEventQueue
 from .run_summarizer import BatchRunSummarizer
 from .utils import BadRequestError
 from .work_item import WorkItemRequest
+from .work_item_processor import WorkItemProcessor
+
 
 logger = logging.getLogger("batch")
 
@@ -170,6 +172,16 @@ class BatchRequest(ABC):
         Make WorkItemRequests based on the BatchRequest.
         This is dependent on the concrete implementation of BatchRequest subtypes, and each subtype
         should have one or more subtypes of WorkItemRequest it can factory.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def get_work_item_processor() -> WorkItemProcessor:
+        """
+        Returns an instance of a WorkItemProcessor subtype that is capable of handling
+        this batch. The WorkItemProcessor must be able to process any WorkItemRequest subtype
+        produced by this BatchRequest's `make_work_items()`.
         """
         pass
 

--- a/batchkit/work_item.py
+++ b/batchkit/work_item.py
@@ -2,32 +2,12 @@
 # Licensed under the MIT License.
 
 import copy
-import multiprocessing
-from multiprocessing import current_process, RLock
-import os
-import traceback
 from abc import ABC, abstractmethod
 from typing import Optional, List, Tuple
 import jsonpickle
 import heapq
-import cProfile
 
-from batchkit.logger import LogEventQueue, LogLevel
-
-# Process-wide (work item pool worker) globals for CancellationToken, LogEventQueue, WorkItemLock_GlobalScope.
-# These are objects that may not be serializable and are needed by all work items that a pool worker processes.
-proc_scope_ct: Optional[multiprocessing.Event] = None
-proc_scope_leq: Optional[LogEventQueue] = None
-proc_scope_global_workitem_lock: Optional[RLock] = None
-
-
-def init_proc_scope(
-        cancellation_token: multiprocessing.Event, log_event_queue: LogEventQueue,
-        global_workitem_lock: RLock):
-    global proc_scope_ct, proc_scope_leq, proc_scope_global_workitem_lock
-    proc_scope_ct = cancellation_token
-    proc_scope_leq = log_event_queue
-    proc_scope_global_workitem_lock = global_workitem_lock
+from batchkit.logger import LogEventQueue
 
 
 class WorkItemRequest(ABC):
@@ -37,46 +17,6 @@ class WorkItemRequest(ABC):
 
     def serialize_json(self):
         return jsonpickle.encode(self)
-
-    def process(self, endpoint_config: dict, rtf: float,
-                enable_profiling: bool = False,
-
-                # Work-item specifics do not need to be provided if they can be defaulted
-                # from process scope via init_proc_scope().
-                log_event_queue: Optional[LogEventQueue] = None,
-                cancellation_token: Optional[multiprocessing.Event] = None,
-                global_workitem_lock: Optional[RLock] = None):
-
-        if enable_profiling:
-            pr = cProfile.Profile()
-            pr.enable()
-
-        leq: LogEventQueue = log_event_queue if log_event_queue else proc_scope_leq
-        ct: multiprocessing.Event = cancellation_token if cancellation_token else proc_scope_ct
-        gwil: RLock = global_workitem_lock if global_workitem_lock else proc_scope_global_workitem_lock
-
-        leq.debug("Process: {0} starting to process work item of Type: {1}  and Filepath: {2}".format(
-            current_process().name, type(self).__name__, self.filepath))
-        try:
-            result: WorkItemResult = self.process_impl(endpoint_config, rtf, leq, ct, gwil)
-        except Exception as err:
-            tb = traceback.format_exc()
-            leq.debug("{0}: Exception in WorkItemRequest.process(): {1}\n{2}".format(
-                type(self).__name__, type(err).__name__, tb))
-            raise err
-        leq.debug("Process: {0} finished processing work item of Type: {1}  and Filepath: {2}".format(
-            current_process().name, type(self).__name__, self.filepath))
-
-        if enable_profiling:
-            pr.disable()
-            pr.dump_stats("/tmp/{0}_profile".format(os.path.basename(self.filepath)))
-        return result
-
-    @abstractmethod
-    def process_impl(self, endpoint_config: dict, rtf: float,
-                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
-                     global_workitem_lock: RLock):
-        pass
 
     def priority(self) -> int:   # noqa; intended virtual override
         """
@@ -98,15 +38,10 @@ class SentinelWorkItemRequest(WorkItemRequest):
     def __init__(self):
         super().__init__("STOP", "")
 
-    def process_impl(self, endpoint_config: dict, rtf: float,
-                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
-                     global_workitem_lock: RLock):
-        return None
-
 
 class WorkItemQueue:
     """
-    Non-thread-safe priority queue.
+    Non-thread-safe priority queue for work items.
     """
     def __init__(self, logger: LogEventQueue):
         self._arr: List[Tuple[int, WorkItemRequest]] = []

--- a/batchkit/work_item_processor.py
+++ b/batchkit/work_item_processor.py
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import multiprocessing
+from multiprocessing import current_process, RLock
+import os
+import traceback
+from abc import ABC, abstractmethod
+from typing import Optional, List
+import cProfile
+
+from batchkit.logger import LogEventQueue
+from batchkit.utils import BadRequestError
+from batchkit.work_item import WorkItemRequest, WorkItemResult
+
+
+# Process-wide (work item pool worker) globals for CancellationToken, LogEventQueue, WorkItemLock_GlobalScope.
+# These are objects that may not be serializable and are needed by all work items that a pool worker proc processes.
+proc_scope_ct: Optional[multiprocessing.Event] = None  # Often different between pool worker generations.
+proc_scope_leq: Optional[LogEventQueue] = None
+proc_scope_global_workitem_lock: Optional[RLock] = None
+
+
+def init_proc_scope(
+        cancellation_token: multiprocessing.Event, log_event_queue: LogEventQueue,
+        global_workitem_lock: RLock):
+    global proc_scope_ct, proc_scope_leq, proc_scope_global_workitem_lock
+    proc_scope_ct = cancellation_token
+    proc_scope_leq = log_event_queue
+    proc_scope_global_workitem_lock = global_workitem_lock
+
+
+class WorkItemProcessor(ABC):
+    def __init__(self):
+        pass
+
+    def process(self,
+                work_item: WorkItemRequest,
+                endpoint_config: dict, rtf: float,
+                enable_profiling: bool = False,
+
+                # Work-item specifics do not need to be provided if they can be defaulted
+                # from process scope via init_proc_scope().
+                log_event_queue: Optional[LogEventQueue] = None,
+                cancellation_token: Optional[multiprocessing.Event] = None,
+                global_workitem_lock: Optional[RLock] = None):
+        """
+        Process a work item.
+        """
+
+        leq: LogEventQueue = log_event_queue if log_event_queue else proc_scope_leq
+        ct: multiprocessing.Event = cancellation_token if cancellation_token else proc_scope_ct
+        gwil: RLock = global_workitem_lock if global_workitem_lock else proc_scope_global_workitem_lock
+
+        # Check that this WorkItemProcessor is capable of procesing the `work_item` type.
+        if type(work_item) not in self.work_item_types():
+            msg = "{0}: Called to process a work item of unsupported type: {1}. " + \
+                  "This WorkItemProcessor is specified as handling work items of these types: {2}.".format(
+                    type(self).__name__, type(work_item).__name__, self.work_item_types())
+            leq.critical(msg)
+            raise BadRequestError(msg)
+
+        if enable_profiling:
+            pr = cProfile.Profile()
+            pr.enable()
+
+        leq.info("Process: {0} starting to process work item of Type: {1}  and Filepath: {2}".format(
+            current_process().name, type(work_item).__name__, work_item.filepath))
+        try:
+            result: WorkItemResult = self.process_impl(
+                work_item, endpoint_config, rtf, leq, ct, gwil)
+        except Exception as err:
+            tb = traceback.format_exc()
+            leq.warning("{0}: Exception in WorkItemProcessor.process(): {1}\n{2}".format(
+                type(self).__name__, type(err).__name__, tb))
+            raise err
+        leq.info("Process: {0} finished processing work item of Type: {1}  and Filepath: {2}".format(
+            current_process().name, type(work_item).__name__, work_item.filepath))
+
+        if enable_profiling:
+            pr.disable()
+            pr.dump_stats("/tmp/{0}_profile".format(os.path.basename(work_item.filepath)))
+
+        return result
+
+    @abstractmethod
+    def work_item_types(self) -> List[type]:
+        """
+        This is a framework template method for which subtypes must provide implementation.
+        It should return a List[type] specifying the subtypes of WorkItemRequest that this
+        WorkItemProcessor is capable of processing. Each of those WorkItemRequest subtypes
+        must be processable by the `process_impl() override provided.
+        """
+        pass
+
+    @abstractmethod
+    def process_impl(self,
+                     work_item: WorkItemRequest,
+                     endpoint_config: dict, rtf: float,
+                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
+                     global_workitem_lock: RLock) -> WorkItemResult:
+        """
+        Application-specific implementation of how to process a work item.
+        This is a framework template method for which subtypes must provide implementation.
+        The implementation must be able to handle any subtype of WorkItemRequest that
+        is listed in the `work_item_types()` method which one must also override.
+        """
+        pass
+
+
+class StubWorkItemProcessor(WorkItemProcessor):
+    """
+    Instantiable WorkItemProcessor that is not capable of processing any WorkItemRequest type.
+    This is for testing or null instance equivalent. It will fail process() because it supports
+    an empty list of WorkItemRequest subtypes.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def process_impl(self, work_item: WorkItemRequest, endpoint_config: dict, rtf: float,
+                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
+                     global_workitem_lock: RLock) -> WorkItemResult:
+        raise BadRequestError("StubWorkItemProcessor is not intended for application.")
+
+    def work_item_types(self) -> List[type]:
+        return []

--- a/batchkit_examples/speech_sdk/batch_request.py
+++ b/batchkit_examples/speech_sdk/batch_request.py
@@ -7,14 +7,18 @@ from batchkit.batch_request import BatchRequest
 from batchkit.logger import LogEventQueue
 from batchkit.utils import BadRequestError
 from batchkit.work_item import WorkItemRequest
+from batchkit.work_item_processor import WorkItemProcessor
+
 from batchkit_examples.speech_sdk.batch_config import SpeechSDKBatchConfig
 from batchkit_examples.speech_sdk.endpoint_status import SpeechSDKEndpointStatusChecker
 from batchkit_examples.speech_sdk.run_summarizer import SpeechSDKBatchRunSummarizer
 from batchkit_examples.speech_sdk.work_item import SpeechSDKWorkItemRequest
 import batchkit_examples.speech_sdk.audio as audio
+from batchkit_examples.speech_sdk.work_item_processor import SpeechSDKWorkItemProcessor
 
 
 class SpeechSDKBatchRequest(BatchRequest):
+
     def __init__(self, files: List[str],
                  language: str, diarization: str, nbest: int, profanity: str,
                  allow_resume: bool, enable_sentiment: bool, combine_results: bool = False):
@@ -88,6 +92,10 @@ class SpeechSDKBatchRequest(BatchRequest):
     @staticmethod
     def get_endpoint_status_checker(leq: LogEventQueue) -> SpeechSDKEndpointStatusChecker:
         return SpeechSDKEndpointStatusChecker(leq)
+
+    @staticmethod
+    def get_work_item_processor() -> WorkItemProcessor:
+        return SpeechSDKWorkItemProcessor()
 
     def get_batch_run_summarizer(self) -> SpeechSDKBatchRunSummarizer:
         return SpeechSDKBatchRunSummarizer()

--- a/batchkit_examples/speech_sdk/work_item.py
+++ b/batchkit_examples/speech_sdk/work_item.py
@@ -1,12 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 import json
-import multiprocessing
 from typing import List, Optional
 import audiofile
 import os
 
-from batchkit.logger import LogEventQueue
 from batchkit.work_item import WorkItemRequest, WorkItemResult
 
 
@@ -37,18 +36,6 @@ class SpeechSDKWorkItemRequest(WorkItemRequest):
         self.allow_resume = allow_resume
         self.enable_sentiment = enable_sentiment
         self._cached_duration = None
-
-    def process_impl(self, endpoint_config: dict, rtf: float,
-                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
-                     global_workitem_lock: multiprocessing.RLock):
-        from .recognize import run_recognizer
-        return run_recognizer(
-            self,
-            rtf,
-            endpoint_config,
-            log_event_queue,
-            cancellation_token
-        )
 
     # override
     def priority(self) -> int:

--- a/batchkit_examples/speech_sdk/work_item_processor.py
+++ b/batchkit_examples/speech_sdk/work_item_processor.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import multiprocessing
+from typing import List
+
+from batchkit.logger import LogEventQueue
+from batchkit.work_item import WorkItemRequest, WorkItemResult
+from batchkit.work_item_processor import WorkItemProcessor
+from batchkit_examples.speech_sdk.recognize import run_recognizer
+from batchkit_examples.speech_sdk.work_item import SpeechSDKWorkItemRequest
+
+
+class SpeechSDKWorkItemProcessor(WorkItemProcessor):
+    def __init__(self):
+        super().__init__()
+
+    def work_item_types(self) -> List[type]:
+        return [SpeechSDKWorkItemRequest]
+
+    def process_impl(self,
+                     work_item: WorkItemRequest,
+                     endpoint_config: dict, rtf: float,
+                     log_event_queue: LogEventQueue, cancellation_token: multiprocessing.Event,
+                     global_workitem_lock: multiprocessing.RLock) -> WorkItemResult:
+
+        assert isinstance(work_item, SpeechSDKWorkItemRequest)
+        return run_recognizer(
+            work_item,
+            rtf,
+            endpoint_config,
+            log_event_queue,
+            cancellation_token
+        )

--- a/tests/test_batch_request_dependency_injection.py
+++ b/tests/test_batch_request_dependency_injection.py
@@ -11,6 +11,7 @@ from batchkit.batch_request import BatchRequest
 from batchkit.logger import LogEventQueue
 from batchkit.run_summarizer import BatchRunSummarizer
 from batchkit.work_item import WorkItemRequest, WorkItemResult
+from batchkit.work_item_processor import WorkItemProcessor, StubWorkItemProcessor
 
 logger = logging.getLogger("test_dependency_injection")
 # logger.level = logging.DEBUG
@@ -81,6 +82,10 @@ class TBatchRequest(BatchRequest):
                         cache_search_dirs: List[str],
                         log_dir: str) -> List[TWorkItemRequest]:
         return [TWorkItemRequest(f, output_dir, self.some_int) for f in self.files]
+
+    @staticmethod
+    def get_work_item_processor() -> WorkItemProcessor:
+        return StubWorkItemProcessor()
 
 
 class DependencyInjectionTestCase(TestCase):

--- a/tests/test_e2e_stress_mock_speechsdk.py
+++ b/tests/test_e2e_stress_mock_speechsdk.py
@@ -302,7 +302,7 @@ class UnstableSDKTestCase(object):
                             '-input_folder', tempdir_in,
                             '-scratch_folder', tempdir_scratch,
                             '-log_folder', tempdir_log,
-                            '-console_log_level', 'INFO',
+                            '-console_log_level', 'INFO',  # DEBUG
                             '-file_log_level', 'DEBUG',
                             '-nbest', '1',
                             '-m', 'DAEMON' if daemon_mode else 'ONESHOT',


### PR DESCRIPTION
Add WorkItemProcessor abstraction into the framework to factor out specification of how work items are processed from the WorkItemRequest and WorkItemResponse objects. As with the other framework templates, the consumer building application on top of batchkit must extend WorkItemProcessor and override its abstract methods as per Template Method Pattern used throughout the framework.

Changes were applied into the SpeechSDK example as well (batchkit_examples/speech_sdk), the speech-batch-kit.