### PR TITLE
Fix one language daemon mode

### DIFF
--- a/batchkit_examples/speech_sdk/parser.py
+++ b/batchkit_examples/speech_sdk/parser.py
@@ -156,7 +156,7 @@ def parse_cmdline(args=None) -> Namespace:
     if args.scratch_folder is None:
         args.scratch_folder = tempfile.mkdtemp()
 
-    if isinstance(args.language, list) and args.run_mode != 'ONESHOT':
+    if isinstance(args.language, list) and len(args.language) > 1 and args.run_mode != 'ONESHOT':
         parser.error("Multi-language speech-batch-kit can only be used in ONESHOT mode in this version.")
 
     if isinstance(args.language, str):


### PR DESCRIPTION
The language comes in as a list always, even when there is a single language in it. Fix the check for multi-language incompatibility with daemon mode.